### PR TITLE
Feature/viewer api

### DIFF
--- a/.env.build-example
+++ b/.env.build-example
@@ -1,5 +1,6 @@
 NODE_ENV=development
 API_URL=http://api.local.guac.live
 CHAT_URL=http://chat.local.guac.live
+VIEWER_API_URL=http://viewer-api.local.guac.live
 GIPHY_API_KEY=gotem
 SENTRY_DSN=

--- a/components/Chat/index.js
+++ b/components/Chat/index.js
@@ -174,11 +174,11 @@ function ChatComponent(props){
 	}
 
 	const handleViewers = (viewers) => {
-		log('info', 'Chat', 'Viewers: ' + viewers);
-		dispatch({
-			type: 'SET_CHANNEL_VIEWERS',
-			viewers
-		});
+		log('info', 'Chat', 'Chatters: ' + viewers);
+		//dispatch({
+		//	type: 'SET_CHANNEL_VIEWERS',
+		//	viewers
+		//});
 	}
 
 	const handleMessage = (user, msgID, messages) => {

--- a/components/VideoPlayer/index.js
+++ b/components/VideoPlayer/index.js
@@ -10,8 +10,6 @@ import log from '../../utils/log';
 
 import { useDispatch } from 'react-redux';
 
-import { fetchChannel } from '../../actions';
-
 const OFFLINE_POSTER = '/img/offline-poster.png';
 const VIEWER_API_URL = process.env.VIEWER_API_URL;
 function VideoPlayer(props) {

--- a/components/VideoPlayer/index.js
+++ b/components/VideoPlayer/index.js
@@ -141,7 +141,7 @@ function VideoPlayer(props) {
 		require('videojs-hotkeys');
 		// instantiate Video.js
 		player = videojs(videoNode, videoJsOptions, function onPlayerReady() {
-			log('info', null, 'onPlayerReady', this);
+			log('info', 'VideoPlayer', 'onPlayerReady', this);
 		});
 		
         canAutoplay.video().then((obj) => {
@@ -200,9 +200,10 @@ function VideoPlayer(props) {
 				}
 			}
 			if(e.code != 3){
-				//player.error(null);
+				player.error(null);
 				if(props.live){
-					//retry();
+					this.player.poster = videoJsOptions.poster;
+					this.player.play();
 				}
 			}
 		});

--- a/next.config.js
+++ b/next.config.js
@@ -68,6 +68,7 @@ module.exports = nextSourceMaps({
 	env: {
 		API_URL: process.env.API_URL || 'http://api.local.guac.live',
 		CHAT_URL: process.env.CHAT_URL || 'http://chat.local.guac.live',
+		VIEWER_API_URL: process.env.VIEWER_API_URL || 'http://viewer-api.local.guac.live',
 		GIPHY_API_KEY: process.env.GIPHY_API_KEY,
 		SENTRY_DSN: process.env.SENTRY_DSN,
 		OIL_CONFIG: {

--- a/now.json
+++ b/now.json
@@ -7,6 +7,7 @@
       "env": {
         "API_URL": "@guac-api-url",
         "CHAT_URL": "@guac-chat-url",
+        "VIEWER_API_URL": "@guac-viewer-api-url",
         "GIPHY_API_KEY": "@guac-giphy-api-key",
         "SENTRY_DSN": "@guac-sentry-dsn"
       }

--- a/reducers/channel.js
+++ b/reducers/channel.js
@@ -21,7 +21,7 @@ export default function(state = initialState, action) {
 			});
 		break;
 		case 'FETCH_CHANNEL_SUCCESS':
-			return setChannel(state, action.statusCode, action.data);
+			return setChannel(state, action.statusCode, action.data, action.viewers);
 		break;
 		case 'FOLLOW_SUCCESS':
 			return {
@@ -40,11 +40,12 @@ export default function(state = initialState, action) {
 	return state;
 };
 
-function setChannel(state, statusCode, data) {
+function setChannel(state, statusCode, data, viewers) {
 	return {
 		...state,
 		statusCode,
 		data,
+		viewers,
 		loading: false
 	};
 }


### PR DESCRIPTION
- Viewers are now counted using a socket.io-based connection to a "viewer API server". This will count all viewers, even those not using WS-FLV, such as HTTP-FLV and HTTP-HLS. This has been implemented into the VideoPlayer component.
- In addition to the above, channel pages now connect to a similar socket.io-server to receive events for when the stream goes live. You no longer have to refresh a page when someone goes live, this will be done automatically.