### PR TITLE
Revert "_app.js: No need to activate in initialprops"

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -128,6 +128,9 @@ MyApp.getInitialProps = wrapper.getInitialAppProps(async appContext => {
 		locale = 'en';
 	}
 
+	// Load initial catalog based on locale
+	activate(locale);
+
 	// Handle authenticaiton
 	initialize(ctx);
 


### PR DESCRIPTION
This reverts commit 6df995678b56199312d2b4ff09697c9c59fba7c3.